### PR TITLE
CHECK XDG_CONFIG_HOME before appending to home path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colorrs"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 license = "MIT"
 name = "colorrs"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2024"
 description = "A Rust CLI for outputting terminal colour test images"
 authors = ["Emma Alexandria <emma.jellemabutler@gmail.com>"]

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -91,7 +91,18 @@ pub fn get_pattern_dir() -> Option<PathBuf> {
 
 #[cfg(target_family = "unix")]
 pub fn get_pattern_dir() -> Option<PathBuf> {
+    // Default to reading XDG Config
+    let xdg = std::env::var("XDG_CONFIG_HOME");
+
+    if let Ok(path) = xdg {
+        let mut xdg_path = PathBuf::from(path);
+        xdg_path.push("colorrs");
+        return Some(xdg_path);
+    }
+
+    // Otherwise, we append to the home directory
     let home_dir = std::env::home_dir();
+    // If we cant get the home directory, we're SoL
     if home_dir.is_none() {
         return None;
     }


### PR DESCRIPTION
Previously, we didn't check XDG_CONFIG_HOME before constructing a config path from the home variable on Linux systems. This PR fixes that.
